### PR TITLE
Constants deprecation fix & manifest updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > 
 > This a fork of the existing archived project created by vlebourl. Please contribute here.
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
+<!---[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)-->
 [![GitHub release](https://img.shields.io/github/v/release/vlebourl/custom_vesync.svg)](https://GitHub.com/vlebourl/custom_vesync/releases/)
 
 # VeSync custom component for Home Assistant

--- a/custom_components/vesync/common.py
+++ b/custom_components/vesync/common.py
@@ -48,7 +48,7 @@ async def async_process_devices(hass, manager):
         ["cid", "uuid", "mac_id"],
     )
 
-    _LOGGER.warning(
+    _LOGGER.debug(
         "Found the following devices: %s",
         redacted,
     )

--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -1,6 +1,7 @@
 """Constants for VeSync Component."""
 
-from homeassistant.const import DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS, TIME_MINUTES
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 
 DOMAIN = "vesync"
 VS_DISCOVERY = "vesync_discovery_{}"
@@ -72,33 +73,33 @@ SENSOR_TYPES_AIRFRYER = {
     "current_temp": [
         "current_temperature",
         "Current temperature",
-        TEMP_CELSIUS,
+        UnitOfTemperature.CELSIUS,
         None,
-        DEVICE_CLASS_TEMPERATURE,
+        SensorDeviceClass.TEMPERATURE,
         "current_temp",
     ],
     "cook_set_temp": [
         "set_temperature",
         "Set temperature",
-        TEMP_CELSIUS,
+        UnitOfTemperature.CELSIUS,
         None,
-        DEVICE_CLASS_TEMPERATURE,
+        SensorDeviceClass.TEMPERATURE,
         "cook_set_temp",
     ],
     "cook_last_time": [
         "cook_last_time",
         "Cook Remaining",
-        TIME_MINUTES,
+        UnitOfTime.MINUTES,
         "mdi:timer",
-        TIME_MINUTES,
+        UnitOfTime.MINUTES,
         "cook_last_time",
     ],
     "preheat_last_time": [
         "preheat_last_time",
         "Preheat Remaining",
-        TIME_MINUTES,
+        UnitOfTime.MINUTES,
         "mdi:timer",
-        TIME_MINUTES,
+        UnitOfTime.MINUTES,
         "preheat_last_time",
     ],
     "cook_status": [
@@ -112,9 +113,9 @@ SENSOR_TYPES_AIRFRYER = {
     # "remaining_time": [
     #    "remaining_time",
     #    "running:",
-    #    TIME_MINUTES,
+    #    UnitOfTime.MINUTES,
     #    "mdi:timer",
-    #    TIME_MINUTES,
+    #    UnitOfTime.MINUTES,
     #    "remaining_time",
     # ],
 }

--- a/custom_components/vesync/humidifier.py
+++ b/custom_components/vesync/humidifier.py
@@ -6,10 +6,10 @@ from typing import Any, Mapping
 
 from homeassistant.components.humidifier import HumidifierEntity
 from homeassistant.components.humidifier.const import (
+    HumidifierEntityFeature,
     MODE_AUTO,
     MODE_NORMAL,
     MODE_SLEEP,
-    SUPPORT_MODES,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -120,9 +120,9 @@ class VeSyncHumidifierHA(VeSyncDevice, HumidifierEntity):
         return modes
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> HumidifierEntityFeature:
         """Flag supported features."""
-        return SUPPORT_MODES
+        return HumidifierEntityFeature.MODES
 
     @property
     def target_humidity(self) -> int:

--- a/custom_components/vesync/manifest.json
+++ b/custom_components/vesync/manifest.json
@@ -9,9 +9,9 @@
       "macaddress": "*"
     }
   ],
-  "documentation": "https://www.home-assistant.io/integrations/vesync",
+  "documentation": "https://github.com/micahqcade/custom_vesync",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/vlebourl/custom_vesync",
+  "issue_tracker": "https://github.com/micahqcade/custom_vesync",
   "requirements": ["pyvesync==2.1.10"],
   "version": "1.3.0"
 }

--- a/custom_components/vesync/sensor.py
+++ b/custom_components/vesync/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, PERCENTAGE, POWER_WATT
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
@@ -168,9 +168,9 @@ class VeSyncPowerSensor(VeSyncOutletSensorEntity):
         return self.smartplug.power
 
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> UnitOfPower:
         """Return the Watt unit of measurement."""
-        return POWER_WATT
+        return UnitOfPower.WATT
 
     @property
     def state_class(self):
@@ -212,9 +212,9 @@ class VeSyncEnergySensor(VeSyncOutletSensorEntity):
         return self.smartplug.energy_today
 
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> UnitOfEnergy:
         """Return the kWh unit of measurement."""
-        return ENERGY_KILO_WATT_HOUR
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
     def state_class(self):


### PR DESCRIPTION
Starting in Home Assistant `2024.1` users will get bombarded with a log message for every deprecated constant that is being used. While the integration will continue to work, the log messages will continue until this is fixed and will ask the users to report this to the integration maintainer. By release `2025.1`, if these changes haven't been made, the integration will fail to load. This PR addresses the needed changes and is an attempt to get ahead of the 2024.1 release so you aren't bombarded with users attempting to report the issue.

Info regarding deprecations can be found at these two links:
1. https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/
2. https://developers.home-assistant.io/blog/2023/12/19/constant-deprecation

## Specific changes in this PR

### Const.py, humidifier.py, sensor.py

Enums are used (`SensorDeviceClass`, `UnitOfTemperature`, `UnitOfTime`, `HumidifierEntityFeature`, `UnitOfEnergy`, `UnitOfPower`) instead of the deprecated constants.


### common.py

The logging level for devices found has been changed to `debug` instead of `warning`. There is no need to log what devices are returned by the API unless the user is attempting to investigate an issue in which case the appropriate debug level will be set by the user for the integration. Setting the level to warning creates unnecessary noise in a user's log.


### manifest.json

The documentation and issues URL has been changed to your repo. The way it stands, the current deprecation warnings and any future warnings would instruct users to open an issue on the now archived repo instead of this repo. This change will now correctly send users to create reports on this repo. 

The documentation URL was linked to the official VeSync Home Assistant integration - not sure why this was ever the case since that documentation is not 100% reflective of this integration. Custom component documentation should always point to the custom component's repo URL where the README is located.

`Side note`: I see that issues are not enabled on this repo, which means users won't be able to report any issues with the integration until they are enabled.

### README

I commented out the HACS default badge since this repo is not in the [default HACS repo list](https://github.com/hacs/default/blob/master/integration). The badge may confuse users into thinking that they can search for the integration in HACS without needing to add the repository first to HACS (which would be the case if the repo was in fact a default HACS repo). If you do choose to go through with getting this repo added to the default HACS repo, then adding the badge back will involve just removing the markdown comment line.

**Thanks for taking over the repo!**