### PR TITLE
Don't send device list as warning

### DIFF
--- a/custom_components/vesync/common.py
+++ b/custom_components/vesync/common.py
@@ -49,7 +49,7 @@ async def async_process_devices(hass, manager):
         ["cid", "uuid", "mac_id"],
     )
 
-    _LOGGER.warning(
+    _LOGGER.info(
         "Found the following devices: %s",
         redacted,
     )


### PR DESCRIPTION
The detected devices should be `info` or `debug`.

Also, would it be possible to enable the Issues function in GitHub for people to report any issues they are seeing?