### PR TITLE
Added support for new devices

### DIFF
--- a/custom_components/vesync/binary_sensor.py
+++ b/custom_components/vesync/binary_sensor.py
@@ -151,6 +151,7 @@ class VeSyncWaterTankLiftedSensor(VeSyncBinarySensorEntity):
         """Return a value indicating whether the Humidifier's water tank is lifted."""
         return self.smarthumidifier.details["water_tank_lifted"]
 
+
 class VeSyncFilterOpenStateSensor(VeSyncBinarySensorEntity):
     """Filter Open Sensor."""
 

--- a/custom_components/vesync/binary_sensor.py
+++ b/custom_components/vesync/binary_sensor.py
@@ -58,6 +58,8 @@ def _setup_entities(devices, async_add_entities, coordinator):
             entities.append(VeSyncOutOfWaterSensor(dev, coordinator))
         if has_feature(dev, "details", "water_tank_lifted"):
             entities.append(VeSyncWaterTankLiftedSensor(dev, coordinator))
+        if has_feature(dev, "details", "filter_open_state"):
+            entities.append(VeSyncFilterOpenStateSensor(dev, coordinator))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -148,3 +150,21 @@ class VeSyncWaterTankLiftedSensor(VeSyncBinarySensorEntity):
     def is_on(self) -> bool:
         """Return a value indicating whether the Humidifier's water tank is lifted."""
         return self.smarthumidifier.details["water_tank_lifted"]
+
+class VeSyncFilterOpenStateSensor(VeSyncBinarySensorEntity):
+    """Filter Open Sensor."""
+
+    @property
+    def unique_id(self):
+        """Return unique ID for filter open state sensor on device."""
+        return f"{super().unique_id}-filter-open-state"
+
+    @property
+    def name(self):
+        """Return sensor name."""
+        return f"{super().name} filter open state"
+
+    @property
+    def is_on(self) -> bool:
+        """Return a value indicating whether the Humidifier's filter is open."""
+        return self.smarthumidifier.details["filter_open_state"]

--- a/custom_components/vesync/common.py
+++ b/custom_components/vesync/common.py
@@ -146,7 +146,7 @@ class VeSyncBaseEntity(CoordinatorEntity, Entity):
     @property
     def base_name(self):
         """Return the name of the device."""
-        return self.device.device_type
+        return self.device.device_name
 
     @property
     def name(self):

--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -29,7 +29,7 @@ VS_MODE_TURBO = "turbo"
 
 VS_TO_HA_ATTRIBUTES = {"humidity": "current_humidity"}
 
-VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncVital", "VeSyncAirBaseV2"]
+VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncVital"]
 VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S"]
 VS_AIRFRYER_TYPES = ["VeSyncAirFryer158"]
 

--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -25,10 +25,11 @@ VS_MODE_AUTO = "auto"
 VS_MODE_HUMIDITY = "humidity"
 VS_MODE_MANUAL = "manual"
 VS_MODE_SLEEP = "sleep"
+VS_MODE_TURBO = "turbo"
 
 VS_TO_HA_ATTRIBUTES = {"humidity": "current_humidity"}
 
-VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncVital"]
+VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncVital", "VeSyncAirBaseV2"]
 VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S"]
 VS_AIRFRYER_TYPES = ["VeSyncAirFryer158"]
 

--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -29,7 +29,7 @@ VS_MODE_TURBO = "turbo"
 
 VS_TO_HA_ATTRIBUTES = {"humidity": "current_humidity"}
 
-VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncVital"]
+VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncAirBaseV2"]
 VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S"]
 VS_AIRFRYER_TYPES = ["VeSyncAirFryer158"]
 

--- a/custom_components/vesync/fan.py
+++ b/custom_components/vesync/fan.py
@@ -22,6 +22,7 @@ from .const import (
     VS_MODE_AUTO,
     VS_MODE_MANUAL,
     VS_MODE_SLEEP,
+    VS_MODE_TURBO,
     VS_MODES,
     VS_TO_HA_ATTRIBUTES,
 )
@@ -69,15 +70,15 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         self.smartfan = fan
         self._speed_range = (1, 1)
         self._attr_preset_modes = [VS_MODE_MANUAL, VS_MODE_AUTO, VS_MODE_SLEEP]
-        if has_feature(self.smartfan, "config_dict", VS_LEVELS):
-            self._speed_range = (1, max(self.smartfan.config_dict[VS_LEVELS]))
-        if has_feature(self.smartfan, "config_dict", VS_MODES):
+        if has_feature(self.smartfan, "_config_dict", VS_LEVELS):
+            self._speed_range = (1, max(self.smartfan._config_dict[VS_LEVELS]))
+        if has_feature(self.smartfan, "_config_dict", VS_MODES):
             self._attr_preset_modes = [
                 VS_MODE_MANUAL,
                 *[
                     mode
-                    for mode in [VS_MODE_AUTO, VS_MODE_SLEEP]
-                    if mode in self.smartfan.config_dict[VS_MODES]
+                    for mode in [VS_MODE_AUTO, VS_MODE_SLEEP, VS_MODE_TURBO]
+                    if mode in self.smartfan._config_dict[VS_MODES]
                 ],
             ]
         if self.smartfan.device_type == "LV-PUR131S":
@@ -161,6 +162,8 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
             self.smartfan.sleep_mode()
         elif preset_mode == VS_MODE_MANUAL:
             self.smartfan.manual_mode()
+        elif preset_mode == VS_MODE_TURBO:
+            self.smartfan.turbo_mode()
 
         self.schedule_update_ha_state()
 

--- a/custom_components/vesync/fan.py
+++ b/custom_components/vesync/fan.py
@@ -70,15 +70,15 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         self.smartfan = fan
         self._speed_range = (1, 1)
         self._attr_preset_modes = [VS_MODE_MANUAL, VS_MODE_AUTO, VS_MODE_SLEEP]
-        if has_feature(self.smartfan, "config_dict", VS_LEVELS):
-            self._speed_range = (1, max(self.smartfan.config_dict[VS_LEVELS]))
-        if has_feature(self.smartfan, "config_dict", VS_MODES):
+        if has_feature(self.smartfan, "_config_dict", VS_LEVELS):
+            self._speed_range = (1, max(self.smartfan._config_dict[VS_LEVELS]))
+        if has_feature(self.smartfan, "_config_dict", VS_MODES):
             self._attr_preset_modes = [
                 VS_MODE_MANUAL,
                 *[
                     mode
                     for mode in [VS_MODE_AUTO, VS_MODE_SLEEP, VS_MODE_TURBO]
-                    if mode in self.smartfan.config_dict[VS_MODES]
+                    if mode in self.smartfan._config_dict[VS_MODES]
                 ],
             ]
         if self.smartfan.device_type == "LV-PUR131S":

--- a/custom_components/vesync/fan.py
+++ b/custom_components/vesync/fan.py
@@ -70,15 +70,15 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
         self.smartfan = fan
         self._speed_range = (1, 1)
         self._attr_preset_modes = [VS_MODE_MANUAL, VS_MODE_AUTO, VS_MODE_SLEEP]
-        if has_feature(self.smartfan, "_config_dict", VS_LEVELS):
-            self._speed_range = (1, max(self.smartfan._config_dict[VS_LEVELS]))
-        if has_feature(self.smartfan, "_config_dict", VS_MODES):
+        if has_feature(self.smartfan, "config_dict", VS_LEVELS):
+            self._speed_range = (1, max(self.smartfan.config_dict[VS_LEVELS]))
+        if has_feature(self.smartfan, "config_dict", VS_MODES):
             self._attr_preset_modes = [
                 VS_MODE_MANUAL,
                 *[
                     mode
                     for mode in [VS_MODE_AUTO, VS_MODE_SLEEP, VS_MODE_TURBO]
-                    if mode in self.smartfan._config_dict[VS_MODES]
+                    if mode in self.smartfan.config_dict[VS_MODES]
                 ],
             ]
         if self.smartfan.device_type == "LV-PUR131S":

--- a/custom_components/vesync/light.py
+++ b/custom_components/vesync/light.py
@@ -255,7 +255,7 @@ class VeSyncNightLightHA(VeSyncDimmableLightHA):
 
     def turn_on(self, **kwargs):
         """Turn the night light on."""
-        if self.device.config_dict["module"] == "VeSyncAirBypass":
+        if self.device._config_dict["module"] == "VeSyncAirBypass":
             if ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS] < 255:
                 self.device.set_night_light("dim")
             else:
@@ -269,7 +269,7 @@ class VeSyncNightLightHA(VeSyncDimmableLightHA):
 
     def turn_off(self, **kwargs):
         """Turn the night light off."""
-        if self.device.config_dict["module"] == "VeSyncAirBypass":
+        if self.device._config_dict["module"] == "VeSyncAirBypass":
             self.device.set_night_light("off")
         else:
             self.device.set_night_light_brightness(0)

--- a/custom_components/vesync/light.py
+++ b/custom_components/vesync/light.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .common import VeSyncDevice, has_feature
-from .const import DEV_TYPE_TO_HA, DOMAIN, VS_DISCOVERY, VS_LIGHTS, VS_FAN_TYPES
+from .const import DEV_TYPE_TO_HA, DOMAIN, VS_DISCOVERY, VS_FAN_TYPES, VS_LIGHTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -255,7 +255,7 @@ class VeSyncNightLightHA(VeSyncDimmableLightHA):
 
     def turn_on(self, **kwargs):
         """Turn the night light on."""
-        if self.device.config_dict["module"] in VS_FAN_TYPES:
+        if self.device._config_dict["module"] in VS_FAN_TYPES:
             if ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS] < 255:
                 self.device.set_night_light("dim")
             else:
@@ -269,7 +269,7 @@ class VeSyncNightLightHA(VeSyncDimmableLightHA):
 
     def turn_off(self, **kwargs):
         """Turn the night light off."""
-        if self.device.config_dict["module"] in VS_FAN_TYPES:
+        if self.device._config_dict["module"] in VS_FAN_TYPES:
             self.device.set_night_light("off")
         else:
             self.device.set_night_light_brightness(0)

--- a/custom_components/vesync/light.py
+++ b/custom_components/vesync/light.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .common import VeSyncDevice, has_feature
-from .const import DEV_TYPE_TO_HA, DOMAIN, VS_DISCOVERY, VS_LIGHTS
+from .const import DEV_TYPE_TO_HA, DOMAIN, VS_DISCOVERY, VS_LIGHTS, VS_FAN_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -255,7 +255,7 @@ class VeSyncNightLightHA(VeSyncDimmableLightHA):
 
     def turn_on(self, **kwargs):
         """Turn the night light on."""
-        if self.device._config_dict["module"] == "VeSyncAirBypass":
+        if self.device.config_dict["module"] in VS_FAN_TYPES:
             if ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS] < 255:
                 self.device.set_night_light("dim")
             else:
@@ -269,7 +269,7 @@ class VeSyncNightLightHA(VeSyncDimmableLightHA):
 
     def turn_off(self, **kwargs):
         """Turn the night light off."""
-        if self.device._config_dict["module"] == "VeSyncAirBypass":
+        if self.device.config_dict["module"] in VS_FAN_TYPES:
             self.device.set_night_light("off")
         else:
             self.device.set_night_light_brightness(0)

--- a/custom_components/vesync/manifest.json
+++ b/custom_components/vesync/manifest.json
@@ -15,9 +15,9 @@
       "macaddress": "*"
     }
   ],
-  "documentation": "https://github.com/AndreaTomatis/custom_vesync",
+  "documentation": "https://github.com/micahqcade/custom_vesync",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/AndreaTomatis/custom_vesync",
+  "issue_tracker": "https://github.com/micahqcade/custom_vesync",
   "requirements": [
     "pyvesync==2.1.12"
   ],

--- a/custom_components/vesync/manifest.json
+++ b/custom_components/vesync/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/AndreaTomatis/custom_vesync",
   "requirements": [
-    "pyvesync==2.1.10"
+    "pyvesync==2.1.12"
   ],
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/custom_components/vesync/number.py
+++ b/custom_components/vesync/number.py
@@ -52,7 +52,7 @@ def _setup_entities(devices, async_add_entities, coordinator):
             entities.append(VeSyncHumidifierTargetLevelHA(dev, coordinator))
         if has_feature(dev, "details", "warm_mist_level"):
             entities.append(VeSyncHumidifierWarmthLevelHA(dev, coordinator))
-        if has_feature(dev, "config_dict", "levels"):
+        if has_feature(dev, "_config_dict", "levels"):
             entities.append(VeSyncFanSpeedLevelHA(dev, coordinator))
 
     async_add_entities(entities, update_before_add=True)
@@ -77,8 +77,8 @@ class VeSyncFanSpeedLevelHA(VeSyncNumberEntity):
     def __init__(self, device, coordinator) -> None:
         """Initialize the number entity."""
         super().__init__(device, coordinator)
-        self._attr_native_min_value = device.config_dict["levels"][0]
-        self._attr_native_max_value = device.config_dict["levels"][-1]
+        self._attr_native_min_value = device._config_dict["levels"][0]
+        self._attr_native_max_value = device._config_dict["levels"][-1]
         self._attr_native_step = 1
 
     @property
@@ -99,7 +99,7 @@ class VeSyncFanSpeedLevelHA(VeSyncNumberEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the humidifier."""
-        return {"fan speed levels": self.device.config_dict["levels"]}
+        return {"fan speed levels": self.device._config_dict["levels"]}
 
     def set_native_value(self, value):
         """Set the fan speed level."""
@@ -112,8 +112,8 @@ class VeSyncHumidifierMistLevelHA(VeSyncNumberEntity):
     def __init__(self, device, coordinator) -> None:
         """Initialize the number entity."""
         super().__init__(device, coordinator)
-        self._attr_native_min_value = device.config_dict["mist_levels"][0]
-        self._attr_native_max_value = device.config_dict["mist_levels"][-1]
+        self._attr_native_min_value = device._config_dict["mist_levels"][0]
+        self._attr_native_max_value = device._config_dict["mist_levels"][-1]
         self._attr_native_step = 1
 
     @property
@@ -134,7 +134,7 @@ class VeSyncHumidifierMistLevelHA(VeSyncNumberEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the humidifier."""
-        return {"mist levels": self.device.config_dict["mist_levels"]}
+        return {"mist levels": self.device._config_dict["mist_levels"]}
 
     def set_native_value(self, value):
         """Set the mist level."""
@@ -147,8 +147,8 @@ class VeSyncHumidifierWarmthLevelHA(VeSyncNumberEntity):
     def __init__(self, device, coordinator) -> None:
         """Initialize the number entity."""
         super().__init__(device, coordinator)
-        self._attr_native_min_value = device.config_dict["warm_mist_levels"][0]
-        self._attr_native_max_value = device.config_dict["warm_mist_levels"][-1]
+        self._attr_native_min_value = device._config_dict["warm_mist_levels"][0]
+        self._attr_native_max_value = device._config_dict["warm_mist_levels"][-1]
         self._attr_native_step = 1
 
     @property
@@ -169,7 +169,7 @@ class VeSyncHumidifierWarmthLevelHA(VeSyncNumberEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the humidifier."""
-        return {"warm mist levels": self.device.config_dict["warm_mist_levels"]}
+        return {"warm mist levels": self.device._config_dict["warm_mist_levels"]}
 
     def set_native_value(self, value):
         """Set the mist level."""

--- a/custom_components/vesync/number.py
+++ b/custom_components/vesync/number.py
@@ -52,7 +52,7 @@ def _setup_entities(devices, async_add_entities, coordinator):
             entities.append(VeSyncHumidifierTargetLevelHA(dev, coordinator))
         if has_feature(dev, "details", "warm_mist_level"):
             entities.append(VeSyncHumidifierWarmthLevelHA(dev, coordinator))
-        if has_feature(dev, "_config_dict", "levels"):
+        if has_feature(dev, "config_dict", "levels"):
             entities.append(VeSyncFanSpeedLevelHA(dev, coordinator))
 
     async_add_entities(entities, update_before_add=True)
@@ -77,8 +77,8 @@ class VeSyncFanSpeedLevelHA(VeSyncNumberEntity):
     def __init__(self, device, coordinator) -> None:
         """Initialize the number entity."""
         super().__init__(device, coordinator)
-        self._attr_native_min_value = device._config_dict["levels"][0]
-        self._attr_native_max_value = device._config_dict["levels"][-1]
+        self._attr_native_min_value = device.config_dict["levels"][0]
+        self._attr_native_max_value = device.config_dict["levels"][-1]
         self._attr_native_step = 1
 
     @property
@@ -99,7 +99,7 @@ class VeSyncFanSpeedLevelHA(VeSyncNumberEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the humidifier."""
-        return {"fan speed levels": self.device._config_dict["levels"]}
+        return {"fan speed levels": self.device.config_dict["levels"]}
 
     def set_native_value(self, value):
         """Set the fan speed level."""

--- a/custom_components/vesync/number.py
+++ b/custom_components/vesync/number.py
@@ -52,7 +52,7 @@ def _setup_entities(devices, async_add_entities, coordinator):
             entities.append(VeSyncHumidifierTargetLevelHA(dev, coordinator))
         if has_feature(dev, "details", "warm_mist_level"):
             entities.append(VeSyncHumidifierWarmthLevelHA(dev, coordinator))
-        if has_feature(dev, "config_dict", "levels"):
+        if has_feature(dev, "_config_dict", "levels"):
             entities.append(VeSyncFanSpeedLevelHA(dev, coordinator))
 
     async_add_entities(entities, update_before_add=True)
@@ -77,8 +77,8 @@ class VeSyncFanSpeedLevelHA(VeSyncNumberEntity):
     def __init__(self, device, coordinator) -> None:
         """Initialize the number entity."""
         super().__init__(device, coordinator)
-        self._attr_native_min_value = device.config_dict["levels"][0]
-        self._attr_native_max_value = device.config_dict["levels"][-1]
+        self._attr_native_min_value = device._config_dict["levels"][0]
+        self._attr_native_max_value = device._config_dict["levels"][-1]
         self._attr_native_step = 1
 
     @property
@@ -99,7 +99,7 @@ class VeSyncFanSpeedLevelHA(VeSyncNumberEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the humidifier."""
-        return {"fan speed levels": self.device.config_dict["levels"]}
+        return {"fan speed levels": self.device._config_dict["levels"]}
 
     def set_native_value(self, value):
         """Set the fan speed level."""

--- a/custom_components/vesync/sensor.py
+++ b/custom_components/vesync/sensor.py
@@ -8,7 +8,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, DEGREE
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    DEGREE,
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
@@ -269,12 +275,12 @@ class VeSyncAirQualitySensor(VeSyncHumidifierSensorEntity):
     @property
     def unique_id(self):
         """Return unique ID for air quality sensor on device."""
-        return f"{super().unique_id}-air-quality-index"
+        return f"{super().unique_id}-air-quality"
 
     @property
     def name(self):
         """Return sensor name."""
-        return f"{super().name} air quality index"
+        return f"{super().name} air quality"
 
     @property
     def native_value(self):
@@ -291,6 +297,7 @@ class VeSyncAirQualitySensor(VeSyncHumidifierSensorEntity):
         _LOGGER.warning("No air quality index found in '%s'", self.name)
         return None
 
+
 class VeSyncAirQualityPercSensor(VeSyncHumidifierSensorEntity):
     """Representation of an air quality percentage sensor."""
 
@@ -306,12 +313,12 @@ class VeSyncAirQualityPercSensor(VeSyncHumidifierSensorEntity):
     @property
     def unique_id(self):
         """Return unique ID for air quality sensor on device."""
-        return f"{super().unique_id}-air-quality"
+        return f"{super().unique_id}-air-quality-perc"
 
     @property
     def name(self):
         """Return sensor name."""
-        return f"{super().name} air quality"
+        return f"{super().name} air quality percentage"
 
     @property
     def native_unit_of_measurement(self):
@@ -333,12 +340,13 @@ class VeSyncAirQualityPercSensor(VeSyncHumidifierSensorEntity):
         _LOGGER.warning("No air quality percentage found in '%s'", self.name)
         return None
 
+
 class VeSyncAirQualityValueSensor(VeSyncHumidifierSensorEntity):
     """Representation of an air quality sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_device_class = SensorDeviceClass.PM25
-    _attr_native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     def __init__(self, device, coordinator) -> None:
         """Initialize the VeSync device."""
@@ -347,12 +355,12 @@ class VeSyncAirQualityValueSensor(VeSyncHumidifierSensorEntity):
     @property
     def unique_id(self):
         """Return unique ID for air quality sensor on device."""
-        return f"{super().unique_id}-pm25"
+        return f"{super().unique_id}-air-quality-value"
 
     @property
     def name(self):
         """Return sensor name."""
-        return f"{super().name} PM2.5"
+        return f"{super().name} air quality value"
 
     @property
     def native_value(self):
@@ -369,12 +377,13 @@ class VeSyncAirQualityValueSensor(VeSyncHumidifierSensorEntity):
         _LOGGER.warning("No air quality value found in '%s'", self.name)
         return None
 
+
 class VeSyncPM1Sensor(VeSyncHumidifierSensorEntity):
     """Representation of a PM1 sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_device_class = SensorDeviceClass.PM1
-    _attr_native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     def __init__(self, device, coordinator) -> None:
         """Initialize the VeSync device."""
@@ -392,7 +401,7 @@ class VeSyncPM1Sensor(VeSyncHumidifierSensorEntity):
 
     @property
     def native_value(self):
-        """Return the PM1"""
+        """Return the PM1."""
         if has_feature(self.smarthumidifier, "details", "pm1"):
             quality_value = self.smarthumidifier.details["pm1"]
             if isinstance(quality_value, (int, float)):
@@ -405,12 +414,13 @@ class VeSyncPM1Sensor(VeSyncHumidifierSensorEntity):
         _LOGGER.warning("No PM1 value found in '%s'", self.name)
         return None
 
+
 class VeSyncPM10Sensor(VeSyncHumidifierSensorEntity):
     """Representation of a PM10 sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_device_class = SensorDeviceClass.PM10
-    _attr_native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    _attr_native_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     def __init__(self, device, coordinator) -> None:
         """Initialize the VeSync device."""
@@ -428,7 +438,7 @@ class VeSyncPM10Sensor(VeSyncHumidifierSensorEntity):
 
     @property
     def native_value(self):
-        """Return the PM10"""
+        """Return the PM10."""
         if has_feature(self.smarthumidifier, "details", "pm10"):
             quality_value = self.smarthumidifier.details["pm10"]
             if isinstance(quality_value, (int, float)):
@@ -440,6 +450,7 @@ class VeSyncPM10Sensor(VeSyncHumidifierSensorEntity):
             )
         _LOGGER.warning("No PM10 value found in '%s'", self.name)
         return None
+
 
 class VeSyncFilterLifeSensor(VeSyncHumidifierSensorEntity):
     """Representation of a filter life sensor."""
@@ -501,6 +512,7 @@ class VeSyncFilterLifeSensor(VeSyncHumidifierSensorEntity):
         """Return the icon to use in the frontend, if any."""
         return "mdi:air-filter"
 
+
 class VeSyncFanRotateAngleSensor(VeSyncHumidifierSensorEntity):
     """Representation of a fan rotate angle sensor."""
 
@@ -551,6 +563,7 @@ class VeSyncFanRotateAngleSensor(VeSyncHumidifierSensorEntity):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return "mdi:rotate-3d-variant"
+
 
 class VeSyncHumiditySensor(VeSyncHumidifierSensorEntity):
     """Representation of current humidity for a VeSync humidifier."""

--- a/custom_components/vesync/sensor.py
+++ b/custom_components/vesync/sensor.py
@@ -295,7 +295,6 @@ class VeSyncAirQualityPercSensor(VeSyncHumidifierSensorEntity):
     """Representation of an air quality percentage sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_device_class = SensorDeviceClass.AQI
 
     def __init__(self, device, coordinator) -> None:
         """Initialize the VeSync device."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyvesync==2.1.10
+pyvesync==2.1.12


### PR DESCRIPTION
update to latest pyvesync 2.1.12:
- Added Everest Air Support
- Added Vital 200S and Oasis Mist Models

small updates:
- HA device name changed from device_type to device_name
- air quality and PM sensors moved from "diagnostic" to "sensors" section
- filter life moved to "diagnostic" section
- air quality value sensor changed from AQI to PM25 with correct unit of measure
- corrected documentation & issue tracker links