### PR TITLE
Fix async_forward_entry_setup deprecation, add pyvesync as logger, update readme to comment out hacs default badge & include logging doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > 
 > This a fork of the existing archived project created by vlebourl. Please contribute here.
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
-[![GitHub release](https://img.shields.io/github/v/release/vlebourl/custom_vesync.svg)](https://GitHub.com/vlebourl/custom_vesync/releases/)
+<!---[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)-->
+[![GitHub release](https://img.shields.io/github/v/release/micahqcade/custom_vesync.svg)](https://GitHub.com/micahqcade/custom_vesync/releases/)
 
 # VeSync custom component for Home Assistant
 
@@ -34,6 +34,16 @@ You can make sure the custom integration is in use by looking for the following 
 ## Logging
 
 ### Enable debug logging
+
+#### Via Home Assistant UI
+
+Navigate to the Vesync integration and click on `Enable debug logging`. Restart Home Assistant. Give it a few minutes and navigate back to the Vesync integration and disable debug logging. A local log file will get downloaded to your device.
+
+![image](https://github.com/RobertD502/custom_vesync/assets/52541649/c556458c-a0a6-4432-acec-1200fc561d79)
+
+
+
+#### YAML Method
 
 The [logger](https://www.home-assistant.io/integrations/logger/) integration lets you define the level of logging activities in Home Assistant. Turning on debug mode will show more information about unsupported devices in your logbook.
 

--- a/custom_components/vesync/__init__.py
+++ b/custom_components/vesync/__init__.py
@@ -59,8 +59,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error("Unable to login to the VeSync server")
         return False
 
-    forward_setup = hass.config_entries.async_forward_entry_setup
-
     hass.data[DOMAIN] = {config_entry.entry_id: {}}
     hass.data[DOMAIN][config_entry.entry_id][VS_MANAGER] = manager
 
@@ -87,12 +85,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     hass.data[DOMAIN][config_entry.entry_id]["coordinator"] = coordinator
 
     device_dict = await async_process_devices(hass, manager)
+    platforms_list: list = []
 
     for p, vs_p in PLATFORMS.items():
         hass.data[DOMAIN][config_entry.entry_id][vs_p] = []
         if device_dict[vs_p]:
             hass.data[DOMAIN][config_entry.entry_id][vs_p].extend(device_dict[vs_p])
-            hass.async_create_task(forward_setup(config_entry, p))
+            platforms_list.append(p)
+    await hass.config_entries.async_forward_entry_setups(config_entry, platforms_list)
 
     async def async_new_device_discovery(service: ServiceCall) -> None:
         """Discover if new devices should be added."""
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         hass, VS_DISCOVERY.format(PLATFORMS[platform]), new_devices
                     )
                 else:
-                    hass.async_create_task(forward_setup(config_entry, platform))
+                    hass.async_create_task(hass.config_entries.async_forward_entry_setups(config_entry, platform))
 
         for k in PLATFORMS:
             _add_new_devices(k)

--- a/custom_components/vesync/common.py
+++ b/custom_components/vesync/common.py
@@ -49,7 +49,7 @@ async def async_process_devices(hass, manager):
         ["cid", "uuid", "mac_id"],
     )
 
-    _LOGGER.warning(
+    _LOGGER.debug(
         "Found the following devices: %s",
         redacted,
     )

--- a/custom_components/vesync/manifest.json
+++ b/custom_components/vesync/manifest.json
@@ -18,8 +18,11 @@
   "documentation": "https://github.com/micahqcade/custom_vesync",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/micahqcade/custom_vesync",
+  "loggers": [
+    "pyvesync"
+  ],
   "requirements": [
     "pyvesync==2.1.12"
   ],
-  "version": "1.3.2"
+  "version": "1.3.3"
 }


### PR DESCRIPTION
Starting with Home Assistant `2024.7.0` (releasing July 3rd), users will get warnings in their logs that the `async_forward_entry_setup` method has been deprecated and the integration will stop working with Home Assistant `2025.1.0`.

## Specific changes in this PR

### init.py

The deprecated `async_forward_entry_setup` function has been replaced and code modified to work with the `async_forward_entry_setups` function that is to be used instead.

### common.py

The logging level for devices found has been changed to `debug` instead of `warning`. There is no need to log what devices are returned by the API unless the user is attempting to investigate an issue in which case the appropriate debug level will be set by the user for the integration. Setting the level to warning creates unnecessary noise in a user's log.

### manifest.json

* pyvesync has been added to the loggers key which will allow users to see debug logs from both the integration as well as the pyvesync library when they enable debug logging (from the HA UI) on the vesync integration page.
* Integration version has been bumped to `1.3.3`.

### README

* I commented out the HACS default badge since this repo is not in the [default HACS repo list](https://github.com/hacs/default/blob/master/integration). The badge may confuse users into thinking that they can search for the integration in HACS without needing to add the repository first to HACS (which would be the case if the repo was in fact a default HACS repo). If you do choose to go through with getting this repo added to the default HACS repo, then adding the badge back will involve a simple removal of the markdown comment line.
* The release badge has been adjusted to point to your repo instead of the original developer's repo.
* Documentation for how to enable debug logging for the integration via the Home Assistant UI has been added.

## VERY IMPORTANT
* Please enable issues on this repo. Even if you are unable to personally fix an issue, this allows other devs to view any issues that users may be facing and can allow them to create PRs to fix these issues.
* When the integration has been updated, please create a release with the release tag set to the integration version. For example, if you merge this PR, set the release tag to `1.3.3` (since that is the version in the manifest file). In addition, the release notes should inform users what has changed and can/should be used to warn users of any breaking changes.
