### PR TITLE
Add VeSyncSuperior6000S to VS_HUMIDIFIER_TYPES

### DIFF
--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -30,7 +30,7 @@ VS_MODE_TURBO = "turbo"
 VS_TO_HA_ATTRIBUTES = {"humidity": "current_humidity"}
 
 VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncAirBaseV2"]
-VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S"]
+VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S", "VeSyncSuperior6000S"]
 VS_AIRFRYER_TYPES = ["VeSyncAirFryer158"]
 
 


### PR DESCRIPTION
Following the added support in upstream pyvesync - 
[https://github.com/webdjoe/pyvesync/commit/7f49c643d703d37755da41295a4f7a9c8ec456c9
](https://github.com/webdjoe/pyvesync/commit/7f49c643d703d37755da41295a4f7a9c8ec456c9
)