### PR TITLE
Fix to Fan TURN_ON and TURN_OFF features required for HA 2025.1

### DIFF
--- a/custom_components/vesync/__init__.py
+++ b/custom_components/vesync/__init__.py
@@ -59,8 +59,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error("Unable to login to the VeSync server")
         return False
 
-    forward_setup = hass.config_entries.async_forward_entry_setup
-
     hass.data[DOMAIN] = {config_entry.entry_id: {}}
     hass.data[DOMAIN][config_entry.entry_id][VS_MANAGER] = manager
 
@@ -88,18 +86,20 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     device_dict = await async_process_devices(hass, manager)
 
-    for p, vs_p in PLATFORMS.items():
+    for _, vs_p in PLATFORMS.items():
         hass.data[DOMAIN][config_entry.entry_id][vs_p] = []
         if device_dict[vs_p]:
             hass.data[DOMAIN][config_entry.entry_id][vs_p].extend(device_dict[vs_p])
-            hass.async_create_task(forward_setup(config_entry, p))
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, list(PLATFORMS.keys()))
 
     async def async_new_device_discovery(service: ServiceCall) -> None:
         """Discover if new devices should be added."""
         manager = hass.data[DOMAIN][config_entry.entry_id][VS_MANAGER]
         dev_dict = await async_process_devices(hass, manager)
+        platforms_to_setup = []
 
-        def _add_new_devices(platform: str) -> None:
+        async def _add_new_devices(platform: str) -> None:
             """Add new devices to hass."""
             old_devices = hass.data[DOMAIN][config_entry.entry_id][PLATFORMS[platform]]
             if new_devices := list(
@@ -111,10 +111,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         hass, VS_DISCOVERY.format(PLATFORMS[platform]), new_devices
                     )
                 else:
-                    hass.async_create_task(forward_setup(config_entry, platform))
+                    platforms_to_setup.append(platform)
 
         for k in PLATFORMS:
             _add_new_devices(k)
+
+        if platforms_to_setup:
+            await hass.config_entries.async_forward_entry_setups(config_entry, platforms_to_setup)
 
     hass.services.async_register(
         DOMAIN, SERVICE_UPDATE_DEVS, async_new_device_discovery

--- a/custom_components/vesync/fan.py
+++ b/custom_components/vesync/fan.py
@@ -88,9 +88,9 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
     def supported_features(self):
         """Flag supported features."""
         return (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+            FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF | FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
             if self.speed_count > 1
-            else FanEntityFeature.SET_SPEED
+            else FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF | FanEntityFeature.SET_SPEED
         )
 
     @property


### PR DESCRIPTION
This PR restores On/Off functionality for Fan devices in HA 2025.1 by adding FanEntityFeature.TURN_ON and FanEntityFeature.TURN_OFF to supported features.

This along with the async_forward_entry_setups fix from @fcastilloec is required for full functionality on HA 2025.1