### PR TITLE
Migrate to HomeAssistant 2025.6

### DIFF
--- a/custom_components/vesync/__init__.py
+++ b/custom_components/vesync/__init__.py
@@ -90,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.data[DOMAIN][config_entry.entry_id][vs_p] = []
         if device_dict[vs_p]:
             hass.data[DOMAIN][config_entry.entry_id][vs_p].extend(device_dict[vs_p])
-            await hass.config_entries.async_forward_entry_setups(config_entry, p)
+            await hass.config_entries.async_forward_entry_setups(config_entry, [p.value])
 
     async def async_new_device_discovery(service: ServiceCall) -> None:
         """Discover if new devices should be added."""
@@ -109,7 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         hass, VS_DISCOVERY.format(PLATFORMS[platform]), new_devices
                     )
                 else:
-                    await hass.config_entries.async_forward_entry_setups(config_entry, platform)
+                    await hass.config_entries.async_forward_entry_setups(config_entry, [platform.value])
 
         for k in PLATFORMS:
             await _add_new_devices(k)

--- a/custom_components/vesync/__init__.py
+++ b/custom_components/vesync/__init__.py
@@ -97,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         manager = hass.data[DOMAIN][config_entry.entry_id][VS_MANAGER]
         dev_dict = await async_process_devices(hass, manager)
 
-        def _add_new_devices(platform: str) -> None:
+        async def _add_new_devices(platform: str) -> None:
             """Add new devices to hass."""
             old_devices = hass.data[DOMAIN][config_entry.entry_id][PLATFORMS[platform]]
             if new_devices := list(
@@ -112,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     await hass.config_entries.async_forward_entry_setups(config_entry, platform)
 
         for k in PLATFORMS:
-            _add_new_devices(k)
+            await _add_new_devices(k)
 
     hass.services.async_register(
         DOMAIN, SERVICE_UPDATE_DEVS, async_new_device_discovery

--- a/custom_components/vesync/__init__.py
+++ b/custom_components/vesync/__init__.py
@@ -59,8 +59,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error("Unable to login to the VeSync server")
         return False
 
-    forward_setup = hass.config_entries.async_forward_entry_setup
-
     hass.data[DOMAIN] = {config_entry.entry_id: {}}
     hass.data[DOMAIN][config_entry.entry_id][VS_MANAGER] = manager
 
@@ -92,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.data[DOMAIN][config_entry.entry_id][vs_p] = []
         if device_dict[vs_p]:
             hass.data[DOMAIN][config_entry.entry_id][vs_p].extend(device_dict[vs_p])
-            hass.async_create_task(forward_setup(config_entry, p))
+            await hass.config_entries.async_forward_entry_setups(config_entry, p)
 
     async def async_new_device_discovery(service: ServiceCall) -> None:
         """Discover if new devices should be added."""
@@ -111,7 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         hass, VS_DISCOVERY.format(PLATFORMS[platform]), new_devices
                     )
                 else:
-                    hass.async_create_task(forward_setup(config_entry, platform))
+                    await hass.config_entries.async_forward_entry_setups(config_entry, platform)
 
         for k in PLATFORMS:
             _add_new_devices(k)


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

```
AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'. Did you mean: 'async_forward_entry_setups'?
```

Tested on my instance/fork https://github.com/jankaderabek/custom_vesync