### PR TITLE
Fix API change

### DIFF
--- a/custom_components/vesync/__init__.py
+++ b/custom_components/vesync/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.error("Unable to login to the VeSync server")
         return False
 
-    forward_setup = hass.config_entries.async_forward_entry_setup
+    forward_setup = hass.config_entries.async_forward_entry_setups
 
     hass.data[DOMAIN] = {config_entry.entry_id: {}}
     hass.data[DOMAIN][config_entry.entry_id][VS_MANAGER] = manager


### PR DESCRIPTION
Looks like they changed to pluralize the method call:
```
AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'. Did you mean: 'async_forward_entry_setups'?
```